### PR TITLE
Additions: "Also" for side-effects and "debug" for printing debug messages

### DIFF
--- a/Sources/Genything/gen/debug/Gen+also.swift
+++ b/Sources/Genything/gen/debug/Gen+also.swift
@@ -1,0 +1,12 @@
+public extension Gen {
+    /// Invokes the provided closure for each value produced by the receiver in order to perform intermediary actions or side-effects
+    ///
+    /// - Returns: A generator which which produces identical values to the receiver
+    func also(_ run: @escaping (T) throws -> Void) rethrows -> Gen<T> {
+        Gen<T> { ctx in
+            let value = generate(context: ctx)
+            try run(value)
+            return value
+        }
+    }
+}

--- a/Sources/Genything/gen/debug/Gen+debug.swift
+++ b/Sources/Genything/gen/debug/Gen+debug.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public extension Gen {
+    /// Logs a print statement for each value produced by the receiver
+    ///
+    /// - Parameter tag: Optional tag which can be used to easily identify which debug statement a log belongs to
+    ///
+    /// - Returns: A generator which which produces identical values to the receiver
+    func debug(_ tag: String = "", file: StaticString = #fileID, line: UInt = #line) -> Gen<T> {
+        let prefix: String = {
+            if tag.isEmpty {
+                return "\(file):\(line)"
+            }
+            return "\(tag)"
+        }()
+
+        return also {
+            log(prefix, $0)
+        }
+    }
+
+    private func log(_ tag: String, _ value: T) {
+        let timestamp = dateFormatter.string(from: Date())
+        print("\(timestamp): [\(tag)] -> \(value)")
+    }
+}
+
+private var dateFormatter: DateFormatter = {
+    let df = DateFormatter()
+    df.dateFormat = "HH:mm:ss.SSS"
+    return df
+}()

--- a/Tests/GenythingTests/gen/debug/GenAlsoTests.swift
+++ b/Tests/GenythingTests/gen/debug/GenAlsoTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+import Genything
+import GenythingTest
+
+class Gen_AlsoTests: XCTestCase {
+    func test_also_runs_side_effect_once_per_generation() {
+        let iterations = 100
+
+        var count = 0
+        _ = Gen.constant(()).also {
+            count += 1
+        }.take(iterations)
+
+        XCTAssertEqual(iterations, count)
+    }
+}

--- a/Tests/GenythingTests/gen/debug/GenDebugTests.swift
+++ b/Tests/GenythingTests/gen/debug/GenDebugTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+import Genything
+import GenythingTest
+
+class Gen_DebugTests: XCTestCase {
+    func test_debug_printsAsExpected() {
+        _ = Gen.from(1...5)
+            .debug()
+            .map { $0 * 2 }
+            .debug("*2")
+            .take(5)
+    }
+}


### PR DESCRIPTION
Creates a debug function which can be used to log print statements to aid in debugging

e.g.
```swift
Gen
    .from(1...5)
    .debug()
    .map { $0 * 2 }
    .debug("*2")
    .take(5)
```

will produce:
```
14:22:42.205: [GenythingTests/GenDebugTests.swift:8] -> 5
14:22:42.205: [*2] -> 10
14:22:42.205: [GenythingTests/GenDebugTests.swift:8] -> 4
14:22:42.205: [*2] -> 8
14:22:42.205: [GenythingTests/GenDebugTests.swift:8] -> 3
14:22:42.205: [*2] -> 6
```

In addition I've added `also` to the toolkit which was used to make debug possible.

`also` can be used to introduce side-effects during value generation, something that I wouldn't really recommend unless perhaps to implement a different logging/debugging solution.