### PR TITLE
Remove the default constructor from random source

### DIFF
--- a/Example/GenythingExample/Pages/Business Cards/BusinessListView.swift
+++ b/Example/GenythingExample/Pages/Business Cards/BusinessListView.swift
@@ -65,7 +65,7 @@ struct BusinessListView: View {
             addressLine1: Fake.Addresses.streetLine.next(rs),
             addressLine2: addressLine2Gen.next(rs)
         )
-    }.take(50, randomSource: RandomSource())
+    }.take(50, randomSource: .predetermined())
 
     var body: some View {
         List {

--- a/Example/Playground.playground/Pages/Creating your own generators.xcplaygroundpage/Contents.swift
+++ b/Example/Playground.playground/Pages/Creating your own generators.xcplaygroundpage/Contents.swift
@@ -17,7 +17,7 @@ struct RandomDate: Generator {
     }
 }
 
-RandomDate().next(RandomSource()) /// Returns: An arbitrary date
+RandomDate().next(.predetermined()) /// Returns: An arbitrary date
 
 // It's also important to mention that while abstracting randomness is a large part of what makes Genything great, there is no requirement:
 
@@ -28,7 +28,7 @@ struct CurrentDate: Generator {
     }
 }
 
-CurrentDate().next(RandomSource()) /// Returns: The current date
+CurrentDate().next(.predetermined()) /// Returns: The current date
 
 // Many Genything operators are themselves just Generators:
 
@@ -45,7 +45,7 @@ let unixTimeGenerator = MapOperator(source: CurrentDate()) { date in
     date.timeIntervalSince1970
 }
 
-unixTimeGenerator.next(RandomSource()) /// Returns: An arbitrary unix time as `TimeInterval`
+unixTimeGenerator.next(.predetermined()) /// Returns: An arbitrary unix time as `TimeInterval`
 
 // We can use this knowledge to create our own operators:
 
@@ -68,8 +68,8 @@ struct FormatDate<Source>: Generator where Source: Generator, Source.T == Date {
     }
 }
 
-FormatDate(source: CurrentDate()).next(RandomSource()) /// Returns: The current date, formatted
-FormatDate(source: RandomDate()).next(RandomSource()) /// Returns: An arbitrary date, formatted
+FormatDate(source: CurrentDate()).next(.predetermined()) /// Returns: The current date, formatted
+FormatDate(source: RandomDate()).next(.predetermined()) /// Returns: An arbitrary date, formatted
 
 // And now you can add this operator to Genything's DSL
 

--- a/Example/Playground.playground/Pages/Modelling Production Data.xcplaygroundpage/Contents.swift
+++ b/Example/Playground.playground/Pages/Modelling Production Data.xcplaygroundpage/Contents.swift
@@ -27,7 +27,7 @@ let userGenerator = AnyGenerator { rs in
     )
 }
 
-userGenerator.next(RandomSource()) /// Returns: An arbitrary user
+userGenerator.next(.predetermined()) /// Returns: An arbitrary user
 
 // As you can see it is not difficult to create a generator which is capable of quickly providing us with arbitrary users of our system. But we can do even better!
 
@@ -93,13 +93,13 @@ let over18UserGen = User.arbitrary.regenerate { user, randomSource in
     user.age = (18...Int.max).arbitrary.next(randomSource)
 }
 
-over18UserGen.next(RandomSource()) /// Returns: An arbitrary user with age >= 18
+over18UserGen.next(.predetermined()) /// Returns: An arbitrary user with age >= 18
 
 let under18UserGen = User.arbitrary.regenerate { user, randomSource in
     user.age = (0..<18).arbitrary.next(randomSource)
 }
 
-under18UserGen.next(RandomSource()) /// Returns: An arbitrary user with age < 18
+under18UserGen.next(.predetermined()) /// Returns: An arbitrary user with age < 18
 
 // We assume that the routine should be invariant to any other User property other than the age
 // By leaving the other properties arbitrary, and conducting multiple tests, we can be reasonably sure of this assumption

--- a/Example/Playground.playground/Pages/Stateful generators.xcplaygroundpage/Contents.swift
+++ b/Example/Playground.playground/Pages/Stateful generators.xcplaygroundpage/Contents.swift
@@ -21,7 +21,7 @@ let counter = Counter()
 
 // We need a random source
 
-let rs = RandomSource()
+let rs: RandomSource = .predetermined()
 
 // Now we can see what it produces
 

--- a/Sources/Genything/Random/RandomSource.swift
+++ b/Sources/Genything/Random/RandomSource.swift
@@ -20,13 +20,6 @@ public class RandomSource {
         self.originalSeed = originalSeed
     }
 
-    /// Initializes a `RandomSource` from a predetermined shared seed
-    ///
-    /// - Returns: A new, independent random source.
-    public convenience init() {
-        self.init(determinism: .predetermined(seed: 2022))
-    }
-
     /// The original seed used to begin random number generation
     ///
     /// To be used for debugging purposes and to "replay" a generation event
@@ -39,7 +32,18 @@ public class RandomSource {
 // MARK: Convenience RandomSource Creators
 
 extension RandomSource {
-    /// Returns: An independent `RandomSource` initialized from a nondeterministic seed
+    /// Returns: An new, independent `RandomSource` initialized by default with a common seed for all Genything users
+    public static func predetermined(seed: UInt64 = 2022) -> RandomSource {
+        .init(determinism: .predetermined(seed: seed))
+    }
+    
+    /// Returns: An new, independent `RandomSource` which can be used to replay a previous deterministic random execution
+    /// - Note: Named to help with discoverability
+    public static func replay(seed: UInt64) -> RandomSource {
+        .init(determinism: .predetermined(seed: seed))
+    }
+    
+    /// Returns: An new, independent `RandomSource` initialized from a nondeterministic seed
     public static func random() -> RandomSource {
         .init(determinism: .random)
     }

--- a/Sources/GenythingTest/Core/TestConfig.swift
+++ b/Sources/GenythingTest/Core/TestConfig.swift
@@ -34,7 +34,7 @@ extension TestConfig {
     private static var `defaultFactory`: () -> TestConfig = {
         TestConfig(
             maxIterations: 1000,
-            randomSource: RandomSource()
+            randomSource: .predetermined()
         )
     }
 

--- a/Tests/GenythingTests/Arbitrary/Instance/ArbitraryCollectionElementTests.swift
+++ b/Tests/GenythingTests/Arbitrary/Instance/ArbitraryCollectionElementTests.swift
@@ -5,7 +5,7 @@ import XCTest
 internal final class ArbitraryCollectionElementTests: XCTestCase {
     func test_creating_a_generator_of_arbitrary_elements() {
         // Given a sequence of arbitrary elements
-        let sequence = [0, 1, 2].arbitrary.sequence(100, randomSource: RandomSource())
+        let sequence = [0, 1, 2].arbitrary.sequence(100, randomSource: .predetermined())
 
         // The sequence should have probably generated every possibility
         XCTAssert(sequence.contains(0))

--- a/Tests/GenythingTests/Arbitrary/Type/FoundationArbitraryTests.swift
+++ b/Tests/GenythingTests/Arbitrary/Type/FoundationArbitraryTests.swift
@@ -7,7 +7,7 @@ internal final class FoundationArbitraryTests: XCTestCase {
         let expectedCount = 100
 
         var datesSet: Set<Date> = Set()
-        for date in Date.arbitrary.sequence(expectedCount, randomSource: RandomSource()) {
+        for date in Date.arbitrary.sequence(expectedCount, randomSource: .predetermined()) {
             datesSet.insert(date)
         }
 

--- a/Tests/GenythingTests/Arbitrary/Type/PizzaArbitraryTests.swift
+++ b/Tests/GenythingTests/Arbitrary/Type/PizzaArbitraryTests.swift
@@ -62,7 +62,7 @@ internal final class PizzaArbitraryTests: XCTestCase {
         let pizzaDistribution = Generators.either(left: hawaiianPizzaGen, right: pepperoniPizzaGen, rightProbability: 0.75)
 
         // Take a statistical sample of pizzas
-        let pizzas = pizzaDistribution.take(1000, randomSource: RandomSource())
+        let pizzas = pizzaDistribution.take(1000, randomSource: .predetermined())
 
         func pizzaQuotient(_ pizzaName: String) -> Double {
             let countOfPizzaName = pizzas.filter { $0.name == pizzaName }.count

--- a/Tests/GenythingTests/Arbitrary/Type/SwiftArbitraryTests.swift
+++ b/Tests/GenythingTests/Arbitrary/Type/SwiftArbitraryTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 internal final class SwiftArbitraryTests: XCTestCase {
     func test_stringGeneration_createsDifferentStrings_withDifferentSizes() throws {
-        let strings = String.arbitrary.take(2, randomSource: RandomSource())
+        let strings = String.arbitrary.take(2, randomSource: .predetermined())
 
         XCTAssertEqual(2, strings.count)
         XCTAssertNotEqual(strings[0], strings[1])
@@ -12,7 +12,7 @@ internal final class SwiftArbitraryTests: XCTestCase {
 
     func test_optional_createsOptionals_andRealValues() {
         let arb = (String?).arbitrary
-        let samples = arb.take(10, randomSource: RandomSource())
+        let samples = arb.take(10, randomSource: .predetermined())
 
         XCTAssert(samples.contains(nil))
 
@@ -22,7 +22,7 @@ internal final class SwiftArbitraryTests: XCTestCase {
     }
 
     func test_boolGeneration_createsRandomBool() {
-        let bools = Bool.arbitrary.take(10, randomSource: RandomSource())
+        let bools = Bool.arbitrary.take(10, randomSource: .predetermined())
         XCTAssertTrue(bools.contains(true))
         XCTAssertTrue(bools.contains(false))
     }

--- a/Tests/GenythingTests/Generator_MonadLaws.swift
+++ b/Tests/GenythingTests/Generator_MonadLaws.swift
@@ -15,8 +15,8 @@ final class Generator_ObeysMonadLaws: XCTestCase {
         let normalResult = increment(value: value)
 
         XCTAssertEqual(
-            flatMapResult.next(.init()),
-            normalResult.next(.init())
+            flatMapResult.next(.predetermined()),
+            normalResult.next(.predetermined())
         )
     }
 
@@ -32,8 +32,8 @@ final class Generator_ObeysMonadLaws: XCTestCase {
         let normalResult = wrap(value: value)
 
         XCTAssertEqual(
-            flatMapResult.next(.init()),
-            normalResult.next(.init())
+            flatMapResult.next(.predetermined()),
+            normalResult.next(.predetermined())
         )
     }
 
@@ -63,7 +63,7 @@ final class Generator_ObeysMonadLaws: XCTestCase {
                 functions[0]($0).flatMap(functions[1])
             }
 
-            return chained.next(RandomSource()) == nested.next(RandomSource())
+            return chained.next(.predetermined()) == nested.next(.predetermined())
         }
     }
 }

--- a/Tests/GenythingTests/Generators/Combinations/Generators_OneOfTests.swift
+++ b/Tests/GenythingTests/Generators/Combinations/Generators_OneOfTests.swift
@@ -11,7 +11,7 @@ final class Generators_OneOfTests: XCTestCase {
         // Count which bucket we are taking from
         let countGen0 = Generators
             .one(of: [gen0, gen1])
-            .take(iterations, randomSource: RandomSource())
+            .take(iterations, randomSource: .predetermined())
             .filter { $0 == 0 }
             .count
 

--- a/Tests/GenythingTests/Generators/Combinations/Generators_WeightedTests.swift
+++ b/Tests/GenythingTests/Generators/Combinations/Generators_WeightedTests.swift
@@ -7,7 +7,7 @@ final class Generators_WeightedTests: XCTestCase {
         let values = Generators.weighted([
             (1, "A"),
             (1, "B"),
-        ]).sequence(1000, randomSource: RandomSource()).countDistinct()
+        ]).sequence(1000, randomSource: .predetermined()).countDistinct()
 
         guard
             let a = values["A"],
@@ -23,7 +23,7 @@ final class Generators_WeightedTests: XCTestCase {
         let values = Generators.weighted([
             (2, "A"),
             (1, "B"),
-        ]).sequence(1000, randomSource: RandomSource()).countDistinct()
+        ]).sequence(1000, randomSource: .predetermined()).countDistinct()
 
         guard
             let a = values["A"],

--- a/Tests/GenythingTests/Generators/Generators_LazyTests.swift
+++ b/Tests/GenythingTests/Generators/Generators_LazyTests.swift
@@ -6,8 +6,8 @@ final class Generators_LazyTests: XCTestCase {
         let iterator = Generators.iterate(0 ... 10)
 
         XCTAssertNotEqual(
-            iterator.take(5, randomSource: RandomSource()),
-            iterator.take(5, randomSource: RandomSource())
+            iterator.take(5, randomSource: .predetermined()),
+            iterator.take(5, randomSource: .predetermined())
         )
     }
 
@@ -17,8 +17,8 @@ final class Generators_LazyTests: XCTestCase {
         }
 
         XCTAssertEqual(
-            lazyIterator.start().take(5, randomSource: RandomSource()),
-            lazyIterator.start().take(5, randomSource: RandomSource())
+            lazyIterator.start().take(5, randomSource: .predetermined()),
+            lazyIterator.start().take(5, randomSource: .predetermined())
         )
     }
 }

--- a/Tests/GenythingTests/Generators/Generators_RandomizedGeneratorTests.swift
+++ b/Tests/GenythingTests/Generators/Generators_RandomizedGeneratorTests.swift
@@ -6,8 +6,8 @@ final class Generators_RandomizedGeneratorTests: XCTestCase {
         let arb = Int.arbitrary
 
         XCTAssertEqual(
-            arb.take(20, randomSource: RandomSource()),
-            arb.randomize(with: RandomSource()).take(20)
+            arb.take(20, randomSource: .predetermined()),
+            arb.randomize(with: .predetermined()).take(20)
         )
     }
 }

--- a/Tests/GenythingTests/Generators/Generators_ShuffleLoop.swift
+++ b/Tests/GenythingTests/Generators/Generators_ShuffleLoop.swift
@@ -41,9 +41,9 @@ final class Generators_ShuffleLoopTests: XCTestCase {
         )
 
         // All cards of the deck are drawn, and they are all unique
-        XCTAssertEqual(52, Set<Card>(cardGen.take(52, randomSource: RandomSource())).count)
+        XCTAssertEqual(52, Set<Card>(cardGen.take(52, randomSource: .predetermined())).count)
 
         // Drawing more from the deck takes from a newly shuffled pile and will repeat values
-        XCTAssertEqual(52, Set<Card>(cardGen.take(53, randomSource: RandomSource())).count)
+        XCTAssertEqual(52, Set<Card>(cardGen.take(53, randomSource: .predetermined())).count)
     }
 }

--- a/Tests/GenythingTests/Operators/Generator_AlsoTests.swift
+++ b/Tests/GenythingTests/Operators/Generator_AlsoTests.swift
@@ -9,7 +9,7 @@ final class Generator_AlsoTests: XCTestCase {
         var count = 0
         _ = Generators.constant(()).also {
             count += 1
-        }.take(iterations, randomSource: RandomSource())
+        }.take(iterations, randomSource: .predetermined())
 
         XCTAssertEqual(iterations, count)
     }

--- a/Tests/GenythingTests/Operators/Generator_DebugTests.swift
+++ b/Tests/GenythingTests/Operators/Generator_DebugTests.swift
@@ -8,6 +8,6 @@ final class Generator_DebugTests: XCTestCase {
             .debug()
             .map { $0 * 2 }
             .debug("*2")
-            .take(5, randomSource: RandomSource())
+            .take(5, randomSource: .predetermined())
     }
 }

--- a/Tests/GenythingTests/Operators/Generator_FlatMapTests.swift
+++ b/Tests/GenythingTests/Operators/Generator_FlatMapTests.swift
@@ -5,6 +5,6 @@ final class Generator_FlatMapTests: XCTestCase {
     func test_flatMap_takes_the_same_values() {
         let gen1 = [1, 2, 3].arbitrary
         let gen2 = gen1.flatMap { Generators.constant($0) }
-        XCTAssertEqual(gen1.take(1000, randomSource: RandomSource()), gen2.take(1000, randomSource: RandomSource()))
+        XCTAssertEqual(gen1.take(1000, randomSource: .predetermined()), gen2.take(1000, randomSource: .predetermined()))
     }
 }

--- a/Tests/GenythingTests/Operators/Generator_MapTests.swift
+++ b/Tests/GenythingTests/Operators/Generator_MapTests.swift
@@ -7,8 +7,8 @@ final class Generator_MapTests: XCTestCase {
         let gen2 = gen1.map { $0 }
 
         XCTAssertEqual(
-            gen1.take(1000, randomSource: RandomSource()),
-            gen2.take(1000, randomSource: RandomSource())
+            gen1.take(1000, randomSource: .predetermined()),
+            gen2.take(1000, randomSource: .predetermined())
         )
     }
 }

--- a/Tests/GenythingTests/Operators/Generator_OrTests.swift
+++ b/Tests/GenythingTests/Operators/Generator_OrTests.swift
@@ -6,7 +6,7 @@ final class Generator_OrTests: XCTestCase {
         let totalCount = 10000
         let trueCount = Generators.constant(false)
             .or(Generators.constant(true))
-            .take(totalCount, randomSource: RandomSource())
+            .take(totalCount, randomSource: .predetermined())
             .filter { $0 }
             .count
 
@@ -17,7 +17,7 @@ final class Generator_OrTests: XCTestCase {
         let totalCount = 10000
         let trueCount = Generators.constant(false)
             .or(Generators.constant(true), otherProbability: 0.0)
-            .take(totalCount, randomSource: RandomSource())
+            .take(totalCount, randomSource: .predetermined())
             .filter { $0 }
             .count
 
@@ -28,7 +28,7 @@ final class Generator_OrTests: XCTestCase {
         let totalCount = 10000
         let trueCount = Generators.constant(false)
             .or(Generators.constant(true), otherProbability: 1.0)
-            .take(totalCount, randomSource: RandomSource())
+            .take(totalCount, randomSource: .predetermined())
             .filter { $0 }
             .count
 

--- a/Tests/GenythingTests/Operators/Generator_ScanTests.swift
+++ b/Tests/GenythingTests/Operators/Generator_ScanTests.swift
@@ -10,7 +10,7 @@
 //
 //        let result = Exhaustive.Loop(range)
 //            .scan(0) { $0 + $1 }
-//            .take(range.count, randomSource: RandomSource())
+//            .take(range.count, randomSource: .predetermined())
 //
 //        XCTAssertEqual([0, 1, 3, 6, 10, 15], result)
 //    }
@@ -20,7 +20,7 @@
 //
 //        let result = Generators.constant(0)
 //            .scan(0) { acc, _ in acc + 1 }
-//            .take(range.count, randomSource: RandomSource())
+//            .take(range.count, randomSource: .predetermined())
 //
 //        XCTAssertEqual([1, 2, 3, 4, 5, 6], result)
 //    }
@@ -30,7 +30,7 @@
 //
 //        let result = Generators.constant(0)
 //            .scan(0) { acc, _ in acc + 2 }
-//            .take(range.count, randomSource: RandomSource())
+//            .take(range.count, randomSource: .predetermined())
 //
 //        XCTAssertEqual([2, 4, 6, 8, 10, 12], result)
 //    }
@@ -43,6 +43,6 @@
 //                average * 0.5 + Double(newValue) * 0.5
 //            }
 //            .debug("average")
-//            .sequence(100, randomSource: RandomSource()).forEach { _ in }
+//            .sequence(100, randomSource: .predetermined()).forEach { _ in }
 //    }
 //}

--- a/Tests/GenythingTests/Operators/Generator_ZipTests.swift
+++ b/Tests/GenythingTests/Operators/Generator_ZipTests.swift
@@ -41,19 +41,19 @@ final class Generator_ZipTests: XCTestCase {
 
     func test_3Gen_staticZip_generateExpectedValues() {
         testZip(argsCount: 3) { gens in
-            Generators.zip(gens[0], gens[1], gens[2]).next(RandomSource())
+            Generators.zip(gens[0], gens[1], gens[2]).next(.predetermined())
         }
     }
 
     func test_4Gen_staticZip_generateExpectedValues() {
         testZip(argsCount: 4) { gens in
-            Generators.zip(gens[0], gens[1], gens[2], gens[3]).next(RandomSource())
+            Generators.zip(gens[0], gens[1], gens[2], gens[3]).next(.predetermined())
         }
     }
 
     func test_5Gen_staticZip_generateExpectedValues() {
         testZip(argsCount: 5) { gens in
-            Generators.zip(gens[0], gens[1], gens[2], gens[3], gens[4]).next(RandomSource())
+            Generators.zip(gens[0], gens[1], gens[2], gens[3], gens[4]).next(.predetermined())
         }
     }
 
@@ -64,7 +64,7 @@ final class Generator_ZipTests: XCTestCase {
             Generators.zip(gens[0], gens[1], gens[2]) { a, b, c in
                 a + b + c
             }
-            .next(RandomSource())
+            .next(.predetermined())
         }
     }
 
@@ -73,7 +73,7 @@ final class Generator_ZipTests: XCTestCase {
             Generators.zip(gens[0], gens[1], gens[2], gens[3]) { a, b, c, d in
                 a + b + c + d
             }
-            .next(RandomSource())
+            .next(.predetermined())
         }
     }
 
@@ -82,7 +82,7 @@ final class Generator_ZipTests: XCTestCase {
             Generators.zip(gens[0], gens[1], gens[2], gens[3], gens[4]) { a, b, c, d, e in
                 a + b + c + d + e
             }
-            .next(RandomSource())
+            .next(.predetermined())
         }
     }
 

--- a/Tests/GenythingTests/Producers/Generator_SequenceTests.swift
+++ b/Tests/GenythingTests/Producers/Generator_SequenceTests.swift
@@ -7,7 +7,7 @@ internal final class Generator_SequenceTests: XCTestCase {
         let gen = Int.arbitrary
 
         // when I run a loop of size `100`
-        for _ in gen.sequence(100, randomSource: RandomSource()) {
+        for _ in gen.sequence(100, randomSource: .predetermined()) {
             // no-op
         }
 
@@ -22,7 +22,7 @@ internal final class Generator_SequenceTests: XCTestCase {
         // and a counter
         var count = 0
         // when I run a loop and count
-        for _ in gen.sequence(expected, randomSource: RandomSource()) {
+        for _ in gen.sequence(expected, randomSource: .predetermined()) {
             count += 1
         }
         // then count matches expectations
@@ -37,7 +37,7 @@ internal final class Generator_SequenceTests: XCTestCase {
         // and a counter
         var count = 0
         // when I run a loop and count
-        for _ in gen.sequence(0, randomSource: RandomSource()) {
+        for _ in gen.sequence(0, randomSource: .predetermined()) {
             count += 1
         }
         // then count matches expectations

--- a/Tests/GenythingTests/Producers/Generator_TakeTests.swift
+++ b/Tests/GenythingTests/Producers/Generator_TakeTests.swift
@@ -7,7 +7,7 @@ internal final class Generator_TakeTests: XCTestCase {
         let generator = bucket.arbitrary
 
         let count = 100
-        let taken = generator.take(count, randomSource: RandomSource())
+        let taken = generator.take(count, randomSource: .predetermined())
 
         XCTAssertEqual(count, taken.count)
 

--- a/Tests/GenythingTests/Random/RandomSourceTests.swift
+++ b/Tests/GenythingTests/Random/RandomSourceTests.swift
@@ -5,8 +5,8 @@ internal final class RandomSourceTests: XCTestCase {
     func test_using_a_RandomSource() {
         // A new randomSource is created each execution
         XCTAssertEqual(
-            Int.arbitrary.next(RandomSource()),
-            Int.arbitrary.next(RandomSource())
+            Int.arbitrary.next(.predetermined()),
+            Int.arbitrary.next(.predetermined())
         )
 
         // To introduce randomness we need to track our randomSource
@@ -20,7 +20,7 @@ internal final class RandomSourceTests: XCTestCase {
 
     func test_generate_one_with_same_seed_produces_same() {
         let calls = (1 ... 100).map { _ in
-            (1 ... 100).arbitrary.next(RandomSource())
+            (1 ... 100).arbitrary.next(.predetermined())
         }
 
         let allCallsAreSame = calls.allSatisfy {
@@ -54,8 +54,8 @@ internal final class RandomSourceTests: XCTestCase {
     }
 
     func test_multiple_calls_with_same_seed_produce_same() {
-        let first = (1 ... 100).arbitrary.take(1000, randomSource: RandomSource())
-        let second = (1 ... 100).arbitrary.take(1000, randomSource: RandomSource())
+        let first = (1 ... 100).arbitrary.take(1000, randomSource: .predetermined())
+        let second = (1 ... 100).arbitrary.take(1000, randomSource: .predetermined())
 
         XCTAssertEqual(first, second)
     }
@@ -64,7 +64,7 @@ internal final class RandomSourceTests: XCTestCase {
         let result = Generators.zip(
             (1 ... 100).arbitrary,
             (1 ... 100).arbitrary
-        ).take(1000, randomSource: RandomSource())
+        ).take(1000, randomSource: .predetermined())
 
         XCTAssertNotEqual(
             result.map { $0.0 },

--- a/Tests/GenythingTests/examples/DiceRoller.swift
+++ b/Tests/GenythingTests/examples/DiceRoller.swift
@@ -14,7 +14,7 @@ internal final class DiceRollerTests: XCTestCase {
 
     // With enough dice rolls the mean should be very close to 3.5
     func test_d6_mean() {
-        let occurences = d6.take(1_000_000, randomSource: RandomSource())
+        let occurences = d6.take(1_000_000, randomSource: .predetermined())
         let mean = Double(occurences.reduce(0, +)) / Double(occurences.count)
         XCTAssertEqual(mean, 3.5, accuracy: 0.005)
     }


### PR DESCRIPTION
Hoping that this encourages people to extend RandomSource with their own sources, and hopefully makes it more obvious what the source does.