### PR TITLE
Add canImport compile directive protection to all xctest imports

### DIFF
--- a/Sources/Genything/Random/RandomSource.swift
+++ b/Sources/Genything/Random/RandomSource.swift
@@ -36,13 +36,13 @@ extension RandomSource {
     public static func predetermined(seed: UInt64 = 2022) -> RandomSource {
         .init(determinism: .predetermined(seed: seed))
     }
-    
+
     /// Returns: An new, independent `RandomSource` which can be used to replay a previous deterministic random execution
     /// - Note: Named to help with discoverability
     public static func replay(seed: UInt64) -> RandomSource {
         .init(determinism: .predetermined(seed: seed))
     }
-    
+
     /// Returns: An new, independent `RandomSource` initialized from a nondeterministic seed
     public static func random() -> RandomSource {
         .init(determinism: .random)

--- a/Sources/GenythingTest/XCTest/XCTestCase+testAll.swift
+++ b/Sources/GenythingTest/XCTest/XCTestCase+testAll.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Genything
+#if canImport(XCTest)
 import XCTest
 
 // MARK: - Failure Detection / RandomSource storage
@@ -514,3 +515,4 @@ extension XCTestCase {
         )
     }
 }
+#endif

--- a/Sources/GenythingTest/XCTest/XCTestCase+testAllSatisfy.swift
+++ b/Sources/GenythingTest/XCTest/XCTestCase+testAllSatisfy.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Genything
+#if canImport(XCTest)
 import XCTest
 
 // - MARK: Test
@@ -140,3 +141,4 @@ extension XCTestCase {
         )
     }
 }
+#endif

--- a/Sources/GenythingTest/XCTest/fail.swift
+++ b/Sources/GenythingTest/XCTest/fail.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Genything
+#if canImport(XCTest)
 import XCTest
 
 private func rerunInfo(_ randomSource: RandomSource) -> String {
@@ -26,3 +27,4 @@ func fail(
 ) {
     XCTFail("[Genything] - Failed with exception `\(error)`. \(rerunInfo(randomSource))", file: file, line: line)
 }
+#endif


### PR DESCRIPTION
This makes it certain that we cannot cause issues stemming from including code which requires XCTest in source targets.