### PR TITLE
We have Flatten for Sequences, so why not also for meta-generators

### DIFF
--- a/Sources/Genything/Operators/Generator+flatten.swift
+++ b/Sources/Genything/Operators/Generator+flatten.swift
@@ -8,6 +8,16 @@ extension Generator where T: Sequence {
     }
 }
 
+extension Generator where T: Generator {
+    /// Flattens a generator of generators into a generator of the nested generator's elements.
+    ///
+    /// - Returns: A generator which generates it's elements from the nested generator's elements.
+    public func flatten() -> AnyGenerator<T.T> {
+        Generators.FlatMap(source: self) { $0 }
+            .eraseToAnyGenerator()
+    }
+}
+
 extension Generators {
     class Flatten<Source>: Generator where Source: Generator, Source.T: Sequence {
 


### PR DESCRIPTION
Shortcut for `.flatMap { $0 }` in the case of Generators of Generators.