### PR TITLE
Random Source parameterization for arbitrary collection sizes

### DIFF
--- a/Sources/Genything/Arbitrary/Type/Swift+Arbitrary.swift
+++ b/Sources/Genything/Arbitrary/Type/Swift+Arbitrary.swift
@@ -78,11 +78,13 @@ extension Character: Arbitrary {
 extension String: Arbitrary {
     /// A generator of arbitrary `String`s of random sizes
     public static var arbitrary: AnyGenerator<String> {
-        arbitrary()
+        AnyGenerator { $0 }.flatMap { rs in
+            arbitrary(in: 0 ... rs.maxArbitraryCollectionSize)
+        }
     }
 
     /// A generator of arbitrary `String`s of random sizes in`range`
-    public static func arbitrary(in range: ClosedRange<Int> = 0 ... 100) -> AnyGenerator<String> {
+    public static func arbitrary(in range: ClosedRange<Int>) -> AnyGenerator<String> {
         Character.arbitrary
             .expand(toSizeInRange: range)
             .map { String($0) }
@@ -94,11 +96,13 @@ extension String: Arbitrary {
 extension Array: Arbitrary where Element: Arbitrary {
     /// A generator of arbitrary `Array`s of random sizes
     public static var arbitrary: AnyGenerator<Array> {
-        arbitrary()
+        AnyGenerator { $0 }.flatMap { rs in
+            arbitrary(in: 0 ... rs.maxRecursiveArbitraryCollectionSize)
+        }
     }
 
     /// A generator of arbitrary `Array`s of random sizes in `range`
-    public static func arbitrary(in range: ClosedRange<Int> = 0 ... 33) -> AnyGenerator<Array> {
+    public static func arbitrary(in range: ClosedRange<Int>) -> AnyGenerator<Array> {
         Element.arbitrary
             .expand(toSizeInRange: range)
     }

--- a/Sources/Genything/Random/RandomSource.swift
+++ b/Sources/Genything/Random/RandomSource.swift
@@ -27,6 +27,13 @@ public class RandomSource {
 
     /// A type-erased `RandomNumberGenerator`
     public var rng: AnyRandomNumberGenerator
+    
+    /// Controls the maximum size for unbounded arbitrary collections (such as Dictionaries or Arrays) of arbitrary values
+    /// Due to the fact that these collections contain other arbitary values, which may themselves contain further collections this parameter may need to be tweaked for performance reasons.
+    public var maxRecursiveArbitraryCollectionSize: Int = 33
+    
+    /// Controls the maximum size for unbounded arbitrary collections such as Strings
+    public var maxArbitraryCollectionSize: Int = 100
 }
 
 // MARK: Convenience RandomSource Creators


### PR DESCRIPTION
Wouldn't mind some commentary on naming or if this should be nested into a configuration. But this change was a long time coming and I think better than forcing arbitrary defaults in a way that is not configurable whatsoever.

Allows parameterization for the max "size" of arbitrary collections. In order to be truly arbitrary they would need to be infinite, but this is of course not feasible.